### PR TITLE
Fix: Strip HTML tags from title (fixes #75)

### DIFF
--- a/js/map.js
+++ b/js/map.js
@@ -246,8 +246,9 @@ class CourseMap extends Backbone.Controller {
       let t = this.get('displayTitle');
       if (isStringEmpty(t)) t = this.get('title');
       if (isStringEmpty(t)) t = this.get('_id');
+      
       // Strip HTML tags
-      let title = document.createElement("div");
+      const title = document.createElement("div");
       title.innerHTML = t;
       return title.textContent || title.innerText || "";
     }

--- a/js/map.js
+++ b/js/map.js
@@ -248,9 +248,11 @@ class CourseMap extends Backbone.Controller {
       if (isStringEmpty(t)) t = this.get('_id');
       
       // Strip HTML tags
-      const title = document.createElement("div");
+      const title = document.createElement('div');
       title.innerHTML = t;
-      return title.textContent || title.innerText || "";
+      t = $(title).text();
+
+      return t;
     }
     function when(prop, options) {
       if (this.get(prop)) {

--- a/js/map.js
+++ b/js/map.js
@@ -248,9 +248,7 @@ class CourseMap extends Backbone.Controller {
       if (isStringEmpty(t)) t = this.get('_id');
       
       // Strip HTML tags
-      const title = document.createElement('div');
-      title.innerHTML = t;
-      t = $(title).text();
+      t = $(`<div>${t}</div>`).text();
 
       return t;
     }

--- a/js/map.js
+++ b/js/map.js
@@ -246,7 +246,10 @@ class CourseMap extends Backbone.Controller {
       let t = this.get('displayTitle');
       if (isStringEmpty(t)) t = this.get('title');
       if (isStringEmpty(t)) t = this.get('_id');
-      return t;
+      // Strip HTML tags
+      let title = document.createElement("div");
+      title.innerHTML = t;
+      return title.textContent || title.innerText || "";
     }
     function when(prop, options) {
       if (this.get(prop)) {


### PR DESCRIPTION
Fix #75 

### Fix
* Strips HTML from title text

### Testing
For the `displayTitle` of a component, use the following text:
```
Welcome to <span style='font-size: 3rem; color: red;'>Client<i>Name's</i><sup>&trade;</sup> Training</span>
```
The title should display like titles that do not contain HTML.