### PR TITLE
Update: add data-order to nav button (#61)

### DIFF
--- a/js/adapt-devtools.js
+++ b/js/adapt-devtools.js
@@ -384,7 +384,6 @@ class DevtoolsNavigationView extends Backbone.View {
     $('html').addClass('devtools-enabled').toggleClass('devtools-extended', Adapt.devtools.get('_extended'));
     if (this.$el.is('a') || this.$el.is('button')) this.$el.on('click', this.onDevtoolsClicked.bind(this));
     else this.$el.find('a, button').on('click', this.onDevtoolsClicked.bind(this));
-    // keep drawer item to left of PLP, resources, close button etc
     this.listenTo(Adapt, 'pageView:postRender menuView:postRender', this.onContentRendered);
     // ensure render occurs at least once (_isReady will not change to true on menus that exclude content objects)
     this.listenToOnce(Adapt, 'pageView:postRender menuView:postRender', this.render);

--- a/less/devtools.less
+++ b/less/devtools.less
@@ -1,10 +1,6 @@
 .devtools {
   // Nav icons
   // --------------------------------------------------
-  &__nav-btn {
-    .u-float-right;
-  }
-
   &__nav-btn .icon {
     .icon-cog;
   }

--- a/templates/devtoolsNavigation.hbs
+++ b/templates/devtoolsNavigation.hbs
@@ -1,3 +1,3 @@
-<button class="btn-icon nav__btn nav__devtools-btn devtools__nav-btn">
+<button class="btn-icon nav__btn nav__devtools-btn devtools__nav-btn" data-order="9000">
   <span class="icon" aria-hidden="true"></span>
 </button>


### PR DESCRIPTION
Fixes https://github.com/cgkineo/adapt-devtools/issues/61

### Update
Hard code `data-order` as this won't need to be configurable. As it's a development tool, it makes sense this is last in the nav order (alongside any other development/review tools).

The original issue notes that manually adding the `data-order` had no effect on the nav order however this worked as expected for me. See screen shot below.

<img width="611" alt="nav_bar_display" src="https://github.com/cgkineo/adapt-devtools/assets/7045330/83b8a26a-8e35-4b52-bd85-9a8e75b6aa14">


