### PR TITLE
New: Add _debugFile property (fix #74)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,22 @@ Once installed, a button is added to the navigation bar. By default, this is a c
 
 **Important:** if using [adapt-contrib-trickle](https://github.com/adaptlearning/adapt-contrib-trickle), please ensure that you are using the latest version.
 
+## Attributes
+
+The attributes listed below are used in *config.json*.
+
+### **\_devtools** (object)
+
+The Dev Tools object contains the following settings:
+
+#### **\_isEnabled** (boolean)
+
+Controls whether the Dev Tools extension is enabled
+
+#### **\_debugFile** (string)
+
+Path to an optional JSON file used for debugging (e.g. *course/dev.json*). This file contains the property `_modelsToRemove` which represents the identifiers of models (and their descendants) to be completely removed from the course. See *example.json*.
+
 ## General options
 
 ### Question hinting

--- a/example.json
+++ b/example.json
@@ -1,6 +1,7 @@
 // to go in config.json
 "_devtools": {
-  "_isEnabled": true
+  "_isEnabled": true,
+  "_debugFile": ""
 }
 
 /*

--- a/js/adapt-devtools.js
+++ b/js/adapt-devtools.js
@@ -2,6 +2,7 @@ import Adapt from 'core/js/adapt';
 import data from 'core/js/data';
 import wait from 'core/js/wait';
 import drawer from 'core/js/drawer';
+import logging from 'core/js/logging';
 import location from 'core/js/location';
 import AdaptModel from 'core/js/models/adaptModel';
 import DevtoolsModel from './devtools-model';
@@ -435,6 +436,8 @@ Adapt.once('adapt:initialize devtools:enable', () => {
 });
 
 data.on('loaded', async () => {
+  if (!Adapt.devtools.get('_debugFile')) return;
+
   const isDescendant = (model, ancestor) => {
     let parent;
     while ((parent = data._byAdaptID[model.get('_parentId')])) {
@@ -472,9 +475,11 @@ data.on('loaded', async () => {
   wait.begin();
 
   try {
-    const devConfig = await data.getJSON('dev.json');
+    const debugFile = Adapt.devtools.get('_debugFile');
+    const devConfig = await data.getJSON(debugFile);
     processConfig(devConfig);
   } catch (err) {
+    logging.warn(`Dev Tools error loading '_debugFile'. ${err}`);
   } finally {
     wait.end();
   }

--- a/js/adapt-devtools.js
+++ b/js/adapt-devtools.js
@@ -1,6 +1,7 @@
 import Adapt from 'core/js/adapt';
 import data from 'core/js/data';
 import wait from 'core/js/wait';
+import drawer from 'core/js/drawer';
 import location from 'core/js/location';
 import AdaptModel from 'core/js/models/adaptModel';
 import DevtoolsModel from './devtools-model';
@@ -413,7 +414,7 @@ class DevtoolsNavigationView extends Backbone.View {
 
   onDevtoolsClicked (event) {
     if (event && event.preventDefault) event.preventDefault();
-    Adapt.drawer.triggerCustomView(new DevtoolsView().$el, false);
+    drawer.triggerCustomView(new DevtoolsView().$el, false);
   }
 
 }


### PR DESCRIPTION
Fixes #74 

### New
* Adds the `_debugFile` property to specify a debug JSON file to load. This will prevent an error always being thrown when _dev.json_ is missing.

### Notes
I did not see the purpose in adding this to the schemas, but let me know otherwise. Can we even upload _.json_ files to the authoring tool?

### Testing
1. In _config.json_, add `_debugFile` to the Dev Tools config.

```
"_devtools": {
  "_isEnabled": true,
  "_debugFile": "course/dev.json"
},
```
2. Check the console for messages:
- If `_debugFile` is _not_ set, no warning or error message should display.
- Likewise, if `_debugFile` is set with a _valid file path_, no message should display.
- If `_debugFile` is set but the file is _missing_, an error should display.