### PR TITLE
Fix: Expose Adapt variable only when Dev Tools drawer is open (fixes #78)

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,10 +96,10 @@ Toggles trace focus.
 
 ## Developer tools
 
-While the Dev Tools drawer is *open*, the core Adapt object can be reached via the `Adapt` reference for convenience.
+Once the Dev Tools drawer has been *opened* for the first time, the core Adapt object can be reached via the `Adapt` reference for the remainder of the session.
 
 To display the underlying model for any content object, article, block or component, with the browser's console open: hold down the left mouse button on the relevant element then press <kbd>m</kbd>. Note that doing so also creates a global variable named according to the model's unique identifier.
 
 ----------------------------
 **Author / maintainer:** Kineo <br>
-**Cross-platform coverage:** Chrome, Chrome for Android, Firefox (ESR + latest version), Edge, IE11, Safari 14 for macOS/iOS/iPadOS, Opera <br>
+**Cross-platform coverage:** Chrome, Chrome for Android, Firefox (ESR + latest version), Edge, Safari for macOS/iOS/iPadOS, Opera <br>

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Toggles trace focus.
 
 ## Developer tools
 
-The core Adapt object can be reached via window.a for convenience.
+While the Dev Tools drawer is *open*, the core Adapt object can be reached via the `Adapt` reference for convenience.
 
 To display the underlying model for any content object, article, block or component, with the browser's console open: hold down the left mouse button on the relevant element then press <kbd>m</kbd>. Note that doing so also creates a global variable named according to the model's unique identifier.
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,5 @@ The core Adapt object can be reached via window.a for convenience.
 To display the underlying model for any content object, article, block or component, with the browser's console open: hold down the left mouse button on the relevant element then press <kbd>m</kbd>. Note that doing so also creates a global variable named according to the model's unique identifier.
 
 ----------------------------
-**Framework versions:** 5+ <br>
 **Author / maintainer:** Kineo <br>
 **Cross-platform coverage:** Chrome, Chrome for Android, Firefox (ESR + latest version), Edge, IE11, Safari 14 for macOS/iOS/iPadOS, Opera <br>

--- a/js/adapt-devtools.js
+++ b/js/adapt-devtools.js
@@ -1,5 +1,6 @@
 import Adapt from 'core/js/adapt';
 import data from 'core/js/data';
+import drawer from 'core/js/drawer';
 import wait from 'core/js/wait';
 import location from 'core/js/location';
 import AdaptModel from 'core/js/models/adaptModel';
@@ -405,7 +406,7 @@ class DevtoolsNavigationView extends Backbone.View {
   }
 
   onContentRendered (view) {
-    if (view.model.get('_id') === Adapt.location._currentId) {
+    if (view.model.get('_id') === location._currentId) {
       this.stopListening(view.model, 'change:_isReady', this.deferredRender);
       this.listenToOnce(view.model, 'change:_isReady', this.deferredRender);
     }
@@ -413,7 +414,7 @@ class DevtoolsNavigationView extends Backbone.View {
 
   onDevtoolsClicked (event) {
     if (event && event.preventDefault) event.preventDefault();
-    Adapt.drawer.triggerCustomView(new DevtoolsView().$el, false);
+    drawer.triggerCustomView(new DevtoolsView().$el, false);
   }
 
 }

--- a/js/utils.js
+++ b/js/utils.js
@@ -32,11 +32,6 @@ function onDrawerOpened() {
   if (!window.Adapt) { window.Adapt = Adapt; }
 }
 
-function onDrawerClosed() {
-  // Remove Adapt reference when drawer closes
-  window.Adapt = null;
-}
-
 function getAdaptCoreVersion() {
   try {
     if (Adapt.build && Adapt.build.has('package')) return Adapt.build.get('package').version || '>=v3.0.0';
@@ -84,8 +79,7 @@ Adapt.once('adapt:initialize devtools:enable', () => {
   $(window).on('mousedown', onMouseDown);
   $(window).on('mouseup', onMouseUp);
   Adapt.on({
-    'drawer:opened': onDrawerOpened,
-    'drawer:closed': onDrawerClosed
+    'drawer:opened': onDrawerOpened
   });
 });
 

--- a/js/utils.js
+++ b/js/utils.js
@@ -83,7 +83,7 @@ Adapt.once('adapt:initialize devtools:enable', () => {
   $(window).on('keypress', onKeypress);
   $(window).on('mousedown', onMouseDown);
   $(window).on('mouseup', onMouseUp);
-  Adapt.listenTo(Adapt, {
+  Adapt.on({
     'drawer:opened': onDrawerOpened,
     'drawer:closed': onDrawerClosed
   });

--- a/js/utils.js
+++ b/js/utils.js
@@ -1,6 +1,7 @@
 import Adapt from 'core/js/adapt';
 import AdaptModel from 'core/js/models/adaptModel';
 import QuestionView from 'core/js/views/questionView';
+import drawer from 'core/js/drawer';
 
 let mouseTarget = null;
 
@@ -22,6 +23,20 @@ function onKeypress(e) {
   window[id] = model;
   console.log('devtools: add property window.' + id + ':');
   console.log(model.attributes);
+}
+
+function onDrawerOpened() {
+  if (drawer?._drawerView?._customView?.get(0).className !== 'devtools') return;
+
+  // Useful for command-line debugging
+  if (!window.Adapt) {
+    window.Adapt = Adapt;
+  }
+}
+
+function onDrawerClosed() {
+  // Remove Adapt reference when drawer closes
+  window.Adapt = null;
 }
 
 function getAdaptCoreVersion() {
@@ -70,8 +85,10 @@ Adapt.once('adapt:initialize devtools:enable', () => {
   $(window).on('keypress', onKeypress);
   $(window).on('mousedown', onMouseDown);
   $(window).on('mouseup', onMouseUp);
-  // useful for command-line debugging
-  if (!window.Adapt) window.Adapt = Adapt;
+  Adapt.listenTo(Adapt, {
+    'drawer:opened': onDrawerOpened,
+    'drawer:closed': onDrawerClosed
+  });
 });
 
 export default Utils;

--- a/js/utils.js
+++ b/js/utils.js
@@ -29,9 +29,7 @@ function onDrawerOpened() {
   if (drawer?._drawerView?._customView?.get(0).className !== 'devtools') return;
 
   // Useful for command-line debugging
-  if (!window.Adapt) {
-    window.Adapt = Adapt;
-  }
+  if (!window.Adapt) { window.Adapt = Adapt; }
 }
 
 function onDrawerClosed() {

--- a/js/utils.js
+++ b/js/utils.js
@@ -28,7 +28,7 @@ function onKeypress(e) {
 function onDrawerOpened() {
   if (drawer?._drawerView?._customView?.get(0).className !== 'devtools') return;
 
-  // Useful for command-line debugging
+  // Useful for browser console debugging
   if (!window.Adapt) { window.Adapt = Adapt; }
 }
 

--- a/less/devtools.less
+++ b/less/devtools.less
@@ -71,10 +71,6 @@
     background-color: @drawer;
   }
 
-  &__item {
-    margin-bottom: @item-margin / 2;
-  }
-
   &__item-label {
     background-color: @drawer-item;
     color: @drawer-item-inverted;
@@ -118,7 +114,17 @@
   &__item.is-tip {
     padding: @item-padding / 2;
     .drawer-item-body;
-    font-style: italic;
+
+    ul {
+      padding: 1rem;
+      margin: 0;
+    }
+
+    code, kbd {
+      font-style: normal;
+      background: rgba(0,0,0,0.6);
+      padding: 0.1rem;
+    }
   }
 
   .touch &__item.is-tip.auto-correct {

--- a/less/devtools.less
+++ b/less/devtools.less
@@ -116,7 +116,7 @@
     .drawer-item-body;
 
     ul {
-      padding: 1rem;
+      padding: 0.5rem 0 0 1rem;
       margin: 0;
     }
 

--- a/templates/devtools.hbs
+++ b/templates/devtools.hbs
@@ -195,7 +195,7 @@
       <b>Developer tips:</b>
       <ul>
         <li>With the browser console open, left-click and press <kbd>m</kbd> to show the <b>data model</b> for that element.</li>
-        <li>While the Dev Tools drawer is open, the <b>core Adapt object</b> can be reached via the <code>Adapt</code> reference.</li>
+        <li>Once the Dev Tools drawer has been opened, the <b>core Adapt object</b> can be reached via the <code>Adapt</code> reference for the remainder of the session.</li>
       </ul>
     </div>
   </div>

--- a/templates/devtools.hbs
+++ b/templates/devtools.hbs
@@ -44,7 +44,7 @@
 
   <div class="devtools__item is-tip auto-correct">
     <div class="devtools__item-inner">
-      ctrl+click submit to correctly answer questions (ctrl+shift+click for incorrect answer)
+      <kbd>ctrl+click</kbd> submit to correctly answer questions (<kbd>ctrl+shift+click</kbd> for incorrect answer)
     </div>
   </div>
 
@@ -192,7 +192,11 @@
 
   <div class="devtools__item is-tip">
     <div class="devtools__item-inner">
-      Dev tip: with the browser console open, left-click and press <kbd>m</kbd> to show the data model for that element.
+      <b>Developer tips:</b>
+      <ul>
+        <li>With the browser console open, left-click and press <kbd>m</kbd> to show the <b>data model</b> for that element.</li>
+        <li>While the Dev Tools drawer is open, the <b>core Adapt object</b> can be reached via the <code>Adapt</code> reference.</li>
+      </ul>
     </div>
   </div>
 


### PR DESCRIPTION
Fixes #78 

### Fix
* Exposes the Adapt variable only when the Dev Tools drawer is open
* Adds this as a new "dev tip" in the drawer
* Adjust styling in drawer to reduce vertical space and add formatting to keyboard commands
* _README.md_ - Remove required framework version and update text about `Adapt` variable.
* Removed some deprecated references in _js/adapt-devtools.js_

### Testing
1. Open the browser console
2. Type in `Adapt` into the console
3. Open the Dev Tools drawer
4. Type in `Adapt` into the console

### Expected results
`Adapt` will only be defined when the Dev Tools drawer is open. Otherwise, you will see something like `Uncaught ReferenceError: Adapt is not defined`.