### PR TITLE
Fix: Replace deprecated drawer.triggerCustomView with drawer.openCustomView (fixes #85)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,7 +8,7 @@
 * A sentence describing each fix
 
 ### Update
-* A sentence describing each udpate
+* A sentence describing each update
 
 ### New
 * A sentence describing each new feature

--- a/js/adapt-devtools.js
+++ b/js/adapt-devtools.js
@@ -415,7 +415,7 @@ class DevtoolsNavigationView extends Backbone.View {
 
   onDevtoolsClicked (event) {
     if (event && event.preventDefault) event.preventDefault();
-    drawer.triggerCustomView(new DevtoolsView().$el, false);
+    drawer.openCustomView(new DevtoolsView().$el, false);
   }
 
 }


### PR DESCRIPTION
Fixes #85 

### Fix
* Replaces deprecated `drawer.triggerCustomView` with `drawer.openCustomView`