### PR TITLE
Fix: Set items to visited on "Complete page" (fix #89)

### DIFF
--- a/js/adapt-devtools.js
+++ b/js/adapt-devtools.js
@@ -296,7 +296,6 @@ class DevtoolsView extends Backbone.View {
         });
         component.set('_attemptsLeft', Math.max(0, component.set('_attempts') - 1));
       }
-      // console.log(component);
       const isPresentationComponentWithItems = (!component.isTypeGroup('question') && component instanceof ItemsComponentModel);
       if (isPresentationComponentWithItems) {
         component.getChildren().forEach(child => child.set('_isVisited', true));

--- a/js/adapt-devtools.js
+++ b/js/adapt-devtools.js
@@ -5,6 +5,7 @@ import wait from 'core/js/wait';
 import logging from 'core/js/logging';
 import location from 'core/js/location';
 import AdaptModel from 'core/js/models/adaptModel';
+import ItemsComponentModel from 'core/js/models/itemsComponentModel';
 import DevtoolsModel from './devtools-model';
 import PassHalfFail from './pass-half-fail';
 import ToggleBanking from './toggle-banking';
@@ -294,6 +295,11 @@ class DevtoolsView extends Backbone.View {
           _score: 1
         });
         component.set('_attemptsLeft', Math.max(0, component.set('_attempts') - 1));
+      }
+      // console.log(component);
+      const isPresentationComponentWithItems = (!component.isTypeGroup('question') && component instanceof ItemsComponentModel);
+      if (isPresentationComponentWithItems) {
+        component.getChildren().forEach(child => child.set('_isVisited', true));
       }
       component.set('_isComplete', true);
       component.set(currentModel.has('_isInteractionsComplete') ? '_isInteractionsComplete' : '_isInteractionComplete', true);

--- a/js/toggle-completion.js
+++ b/js/toggle-completion.js
@@ -2,6 +2,7 @@ import Adapt from 'core/js/adapt';
 import data from 'core/js/data';
 import location from 'core/js/location';
 import Utils from './utils';
+import ItemsComponentModel from 'core/js/models/itemsComponentModel';
 
 let mouseTarget = null;
 
@@ -24,6 +25,10 @@ function complete(element) {
   const model = Utils.getModelForElement(element) || data.findById(location._currentId);
   if (!model) return;
   function doCompletion(component) {
+    const isPresentationComponentWithItems = (!component.isTypeGroup('question') && component instanceof ItemsComponentModel);
+    if (isPresentationComponentWithItems) {
+      component.getChildren().forEach(child => child.set('_isVisited', true));
+    }
     component.set('_isComplete', true);
   }
   const descendantComponents = model.findDescendantModels('components');


### PR DESCRIPTION
Fix #89 

### Fix
* When using "Complete page" or toggle completion, this will also complete each component's items where applicable.

### Testing
Two different scenarios:
1. Use "Complete page" on a page of presentation components (e.g. Narrative, Accordion).
2. Use toggle completion. Click on a component and, while holding down the mouse button, press 'c'.