### PR TITLE
New: Add the ability for Mac users to use option-click (fixes #92)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Allows the user to toggle visual indicators which reveal how to answer correctly
 
 ### Auto correct
 
-When enabled, automatically provides the correct answer when submit is selected. If not enabled, the user can control-click (or option-click for Mac users) the submit button to have the correct answer provided. Standard question components will be answered naturally; revealing the correct responses, feedback and marking if applicable. The plugin will not attempt to do this for bespoke questions or questions that do not have correct answers (e.g. confidence slider), but their models will still be modified to indicate that they are complete and correct.
+When enabled, automatically provides the correct answer when submit is selected. If not enabled, the user can Control+Click or Alt+Click on Windows / Option+Click for macOS the submit button to have the correct answer provided. Standard question components will be answered naturally; revealing the correct responses, feedback and marking if applicable. The plugin will not attempt to do this for bespoke questions or questions that do not have correct answers (e.g. confidence slider), but their models will still be modified to indicate that they are complete and correct.
 
 ### Tutor
 
@@ -56,7 +56,7 @@ Once selected adapt-devtools will disable Adapt core locking (>=v2.0.9) througho
 
 ### Course map
 
-Select this button to reveal an interactive diagram of the course structure. The diagram will reveal all structural elements (content objects, articles, blocks and components) arranged in an intuitive way, reflecting both the hierarchical relationship of the elements and the vertical arrangement of content within each page. The map can be used to navigate directly to any element in the course. Performing a control-click (or option-click for Mac users) will reveal the model of the selected course element in the browser console.
+Select this button to reveal an interactive diagram of the course structure. The diagram will reveal all structural elements (content objects, articles, blocks and components) arranged in an intuitive way, reflecting both the hierarchical relationship of the elements and the vertical arrangement of content within each page. The map can be used to navigate directly to any element in the course. Performing a Control+Click or Alt+Click on Windows / Option+Click for macOS will reveal the model of the selected course element in the browser console.
 
 The course map uses the following legend:
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Allows the user to toggle visual indicators which reveal how to answer correctly
 
 ### Auto correct
 
-When enabled, automatically provides the correct answer when submit is selected. If not enabled the user can control-click the submit button to have the correct answer provided. Standard question components will be answered naturally; revealing the correct responses, feedback and marking if applicable. The plugin will not attempt to do this for bespoke questions or questions that do not have correct answers (e.g. confidence slider), but their models will still be modified to indicate that they are complete and correct.
+When enabled, automatically provides the correct answer when submit is selected. If not enabled, the user can control-click (or option-click for Mac users) the submit button to have the correct answer provided. Standard question components will be answered naturally; revealing the correct responses, feedback and marking if applicable. The plugin will not attempt to do this for bespoke questions or questions that do not have correct answers (e.g. confidence slider), but their models will still be modified to indicate that they are complete and correct.
 
 ### Tutor
 
@@ -56,13 +56,14 @@ Once selected adapt-devtools will disable Adapt core locking (>=v2.0.9) througho
 
 ### Course map
 
-Select this button to reveal an interactive diagram of the course structure. The diagram will reveal all structural elements (content objects, articles, blocks and components) arranged in an intuitive way, reflecting both the hierarchical relationship of the elements and the vertical arrangement of content within each page. The map can be used to navigate directly to any element in the course. Performing a control-click will reveal the model of the selected course element in the browser console.
+Select this button to reveal an interactive diagram of the course structure. The diagram will reveal all structural elements (content objects, articles, blocks and components) arranged in an intuitive way, reflecting both the hierarchical relationship of the elements and the vertical arrangement of content within each page. The map can be used to navigate directly to any element in the course. Performing a control-click (or option-click for Mac users) will reveal the model of the selected course element in the browser console.
 
 The course map uses the following legend:
-+ **Green fill:** element is complete
-+ **Red fill:** element is incomplete
-+ **Yellow triangle:** element is [trickled](https://github.com/adaptlearning/adapt-contrib-trickle)
-+ **Grey fill:** element is optional (_isOptional:true)
+
+* **Green fill:** element is complete
+* **Red fill:** element is incomplete
+* **Yellow triangle:** element is [trickled](https://github.com/adaptlearning/adapt-contrib-trickle)
+* **Grey fill:** element is optional (`_isOptional: true`)
 
 ### Spoor log
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Allows the user to toggle visual indicators which reveal how to answer correctly
 
 ### Auto correct
 
-When enabled, automatically provides the correct answer when submit is selected. If not enabled, the user can Control+Click or Alt+Click on Windows / Option+Click for macOS the submit button to have the correct answer provided. Standard question components will be answered naturally; revealing the correct responses, feedback and marking if applicable. The plugin will not attempt to do this for bespoke questions or questions that do not have correct answers (e.g. confidence slider), but their models will still be modified to indicate that they are complete and correct.
+When enabled, automatically provides the correct answer when submit is selected. If not enabled, the user can Control+Click or Alt+Click for Windows / Option+Click for macOS the submit button to have the correct answer provided. Standard question components will be answered naturally; revealing the correct responses, feedback and marking if applicable. The plugin will not attempt to do this for bespoke questions or questions that do not have correct answers (e.g. confidence slider), but their models will still be modified to indicate that they are complete and correct.
 
 ### Tutor
 
@@ -56,7 +56,7 @@ Once selected adapt-devtools will disable Adapt core locking (>=v2.0.9) througho
 
 ### Course map
 
-Select this button to reveal an interactive diagram of the course structure. The diagram will reveal all structural elements (content objects, articles, blocks and components) arranged in an intuitive way, reflecting both the hierarchical relationship of the elements and the vertical arrangement of content within each page. The map can be used to navigate directly to any element in the course. Performing a Control+Click or Alt+Click on Windows / Option+Click for macOS will reveal the model of the selected course element in the browser console.
+Select this button to reveal an interactive diagram of the course structure. The diagram will reveal all structural elements (content objects, articles, blocks and components) arranged in an intuitive way, reflecting both the hierarchical relationship of the elements and the vertical arrangement of content within each page. The map can be used to navigate directly to any element in the course. Performing a Control+Click or Alt+Click for Windows / Option+Click for macOS will reveal the model of the selected course element in the browser console.
 
 The course map uses the following legend:
 

--- a/js/auto-answer.js
+++ b/js/auto-answer.js
@@ -36,9 +36,9 @@ class AutoAnswer extends Backbone.Controller {
   onQuestionMouseDown (view, e) {
     // remove hinting if enabled
     if (Adapt.devtools.get('_hintingEnabled')) Hinting.setHinting(view.$el, view.model, false);
-    if ((e.ctrlKey && !e.shiftKey) || Adapt.devtools.get('_autoCorrectEnabled')) {
+    if ((e.ctrlKey && !e.shiftKey) || (e.altKey && !e.shiftKey) || Adapt.devtools.get('_autoCorrectEnabled')) {
       this.answer(view);
-    } else if (e.ctrlKey && e.shiftKey) {
+    } else if ((e.ctrlKey && e.shiftKey) || (e.altKey && e.shiftKey)) {
       this.answer(view, true);
     }
   }

--- a/js/map.js
+++ b/js/map.js
@@ -84,7 +84,7 @@ class MapView extends Backbone.View {
     let id = $target.attr('href').slice(1);
     const model = data.findById(id);
     e.preventDefault();
-    if (e.ctrlKey && this.el.defaultView) {
+    if ((e.ctrlKey || e.altKey) && this.el.defaultView) {
       id = id.replace(/-/g, '');
       this.el.defaultView[id] = model;
       this.el.defaultView.console.log('devtools: add property window.' + id + ':');


### PR DESCRIPTION
Fixes #92 

### New
* Adds the ability for Mac users to use option-click instead of control-click for auto-answering questions and interacting with the course map.
* Note that the Option key on Mac maps to the Alt key on Windows. So, Windows users can now also use alt-click as well.