### PR TITLE
Fix: schema and readme wording for _isEnabled to better explain functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The Dev Tools object contains the following settings:
 
 #### **\_isEnabled** (boolean)
 
-Controls whether the Dev Tools extension is enabled
+Controls whether the Dev Tools extension is shown in the navigation bar or not. Remember to disable/uninstall before going live!
 
 #### **\_debugFile** (string)
 

--- a/properties.schema
+++ b/properties.schema
@@ -19,10 +19,10 @@
                 "_isEnabled": {
                   "type":"boolean",
                   "required":false,
-                  "title": "Enable dev tools",
+                  "title": "Show dev tools in nav bar",
                   "inputType": { "type": "Boolean", "options": [false, true]},
                   "validators": [],
-                  "help": "Set to true to enable 'dev tools' features. Remember to disable/uninstall before going live!"
+                  "help": "Set to true to show 'dev tools' in the navigation bar. Remember to disable/uninstall before going live!"
                 }
               }
             }

--- a/schema/config.schema.json
+++ b/schema/config.schema.json
@@ -15,8 +15,8 @@
           "properties": {
             "_isEnabled": {
               "type": "boolean",
-              "title": "Enable dev tools",
-              "description": "Set to true to enable 'dev tools' features. Remember to disable/uninstall before going live!",
+              "title": "Show dev tools in nav bar",
+              "description": "Set to true to show 'dev tools' in the navigation bar. Remember to disable/uninstall before going live!",
               "default": false,
               "_backboneForms": {
                 "type": "Boolean",


### PR DESCRIPTION
fixes #95 

### Fix
* Changed the working in the schemas and readme to reflect that the `_isEnabled` property only disables the navigation bar icon