### PR TITLE
Fix: Fix kbd/code tag styles (fixes #104)

### DIFF
--- a/less/devtools.less
+++ b/less/devtools.less
@@ -123,7 +123,8 @@
     code, kbd {
       font-style: normal;
       background: rgba(0,0,0,0.6);
-      padding: 0.1rem;
+      color: @white;
+      padding: 0.1rem 0.2rem;
     }
   }
 


### PR DESCRIPTION
Fixes #104 

### Fix
* Ensure `<kbd>` and `<code>` text is readable when dev tools text is dark.
* Adds a little more horizontal padding for readability

### Testing
Set the dev tools to a white color scheme. For example:

```
.devtools {
  background: white;
  color: #000;
}
.devtools__item-label {
  background-color: #fff;
  color: #000;
}
.devtools__section-title-inner {
  background-color: #fff;
}
```

The `<kbd` styles (ex. "ctrl+click") should still be readable.

<img width="305" alt="Screenshot 2025-04-02 at 3 17 24 PM" src="https://github.com/user-attachments/assets/12184f86-f976-4ef7-bee5-7fc9332aeb34" />
