### PR TITLE
Update: Convert html selectors to CSS .html selectors (fixes #103)

### DIFF
--- a/less/devtoolsMap.less
+++ b/less/devtoolsMap.less
@@ -10,7 +10,7 @@
   font-weight: @font-weight-bold;
 }
 
-html.has-devtools-map {
+.html.has-devtools-map {
   body {
     .l-container-responsive(@max-width);
     overflow-x: hidden;


### PR DESCRIPTION
Fix #103 

### Update
* Convert `html` selectors to CSS `.html` selectors in Less

### Requires
* https://github.com/adaptlearning/adapt-contrib-core/pull/654 Needs FW bump once this is approved.