### PR TITLE
Fix: Fix hinting issues with MCQ, GMCQ and Matching (fix #113)

### DIFF
--- a/js/auto-answer.js
+++ b/js/auto-answer.js
@@ -35,13 +35,16 @@ class AutoAnswer extends Backbone.Controller {
   }
 
   onQuestionMouseDown (view, e) {
-    // remove hinting if enabled
-    if (Adapt.devtools.get('_hintingEnabled')) Hinting.setHinting(view.$el, view.model, false);
+    let answered = false;
     if ((e.ctrlKey && !e.shiftKey) || (e.altKey && !e.shiftKey) || Adapt.devtools.get('_autoCorrectEnabled')) {
       this.answer(view);
+      answered = true;
     } else if ((e.ctrlKey && e.shiftKey) || (e.altKey && e.shiftKey)) {
       this.answer(view, true);
+      answered = true;
     }
+    if (!answered || !Adapt.devtools.get('_hintingEnabled')) return;
+    Hinting.setHinting(view.$el, view.model, false);
   }
 
   isItemsQuestionModel (model) {

--- a/js/auto-answer.js
+++ b/js/auto-answer.js
@@ -44,6 +44,7 @@ class AutoAnswer extends Backbone.Controller {
       answered = true;
     }
     if (!answered || !Adapt.devtools.get('_hintingEnabled')) return;
+    // remove hinting if enabled
     Hinting.setHinting(view.$el, view.model, false);
   }
 

--- a/js/hinting.js
+++ b/js/hinting.js
@@ -37,7 +37,7 @@ class Hinting extends Backbone.Controller {
     switch (model.get('_component')) {
       case 'mcq':this.setMcqHinting($el, model, hintingEnabled !== false); break;
       case 'gmcq':this.setGmcqHinting($el, model, hintingEnabled !== false); break;
-      case 'matching':this.setMatchingHinting($el, model, hintingEnabled !== false); break;
+      case 'matching': this.setMatchingHinting($el, model, hintingEnabled !== false); break;
       case 'ppq':this.setPpqHinting($el, model, hintingEnabled !== false); break;
       case 'slider':this.setSliderHinting($el, model, hintingEnabled !== false); break;
       case 'textinput':this.setTextInputHinting($el, model, hintingEnabled !== false); break;
@@ -48,42 +48,40 @@ class Hinting extends Backbone.Controller {
   setMcqHinting ($el, model, hintingEnabled) {
     if (hintingEnabled) {
       model.get('_items').forEach((item, index) => {
-        $el.find('.js-mcq-item').eq(index).addClass(item._shouldBeSelected ? 'hint-is-correct' : 'hint-is-incorrect');
+        $el.find('.mcq-item').eq(index).addClass(item._shouldBeSelected ? 'hint-is-correct' : 'hint-is-incorrect');
       });
       return;
     }
-    $el.find('.js-mcq-item').removeClass('hint-is-correct hint-is-incorrect');
+    $el.find('.mcq-item').removeClass('hint-is-correct hint-is-incorrect');
   }
 
   setGmcqHinting ($el, model, hintingEnabled) {
     if (hintingEnabled) {
       model.get('_items').forEach((item, index) => {
-        $el.find('.js-mcq-item').eq(index).addClass(item._shouldBeSelected ? 'hint-is-correct' : 'hint-is-incorrect');
+        $el.find('.gmcq-item').eq(index).addClass(item._shouldBeSelected ? 'hint-is-correct' : 'hint-is-incorrect');
       });
       return;
     }
-    $el.find('.js-mcq-item').removeClass('hint-is-correct hint-is-incorrect');
+    $el.find('.gmcq-item').removeClass('hint-is-correct hint-is-incorrect');
   }
 
   setMatchingHinting ($el, model, hintingEnabled) {
-    if (!hintingEnabled) {
+    const ariaLabels = Adapt.course.get('_globals')._accessibility._ariaLabels;
+    if (hintingEnabled) {
       model.get('_items').forEach((item, itemIndex) => {
         const $item = $el.find('.item').eq(itemIndex);
         const $options = $item.find('.js-dropdown-list-item');
         item._options.forEach((option, optionIndex) => {
-          /* if (Modernizr.touch) { */
-          if (option._isCorrect) $options.eq(optionIndex + 1).find('.js-dropdown-list-item-inner').append('<span class="hint"> (correct)</span>');
-          /* }
-          else {
-            $options.eq(optionIndex+1).addClass(option._isCorrect ? 'hintCorrect' : 'hintIncorrect');
-          } */
+          if (option._isCorrect) {
+            const mcqInner = $options.eq(optionIndex + 1).find('.js-dropdown-list-item-inner');
+            mcqInner.find('.hint').remove();
+            mcqInner.append(`<span class="hint"> (${ariaLabels.correct})</span>`);
+          }
         });
       });
       return;
     }
-    /* if (Modernizr.touch) */
     $el.find('.js-dropdown-list-item-inner .hint').remove();
-    /* else $el.find('option').removeClass('hintCorrect hintIncorrect'); */
   }
 
   setSliderHinting ($el, model, hintingEnabled) {

--- a/js/hinting.js
+++ b/js/hinting.js
@@ -37,7 +37,7 @@ class Hinting extends Backbone.Controller {
     switch (model.get('_component')) {
       case 'mcq':this.setMcqHinting($el, model, hintingEnabled !== false); break;
       case 'gmcq':this.setGmcqHinting($el, model, hintingEnabled !== false); break;
-      case 'matching': this.setMatchingHinting($el, model, hintingEnabled !== false); break;
+      case 'matching':this.setMatchingHinting($el, model, hintingEnabled !== false); break;
       case 'ppq':this.setPpqHinting($el, model, hintingEnabled !== false); break;
       case 'slider':this.setSliderHinting($el, model, hintingEnabled !== false); break;
       case 'textinput':this.setTextInputHinting($el, model, hintingEnabled !== false); break;

--- a/js/hinting.js
+++ b/js/hinting.js
@@ -72,11 +72,10 @@ class Hinting extends Backbone.Controller {
         const $item = $el.find('.item').eq(itemIndex);
         const $options = $item.find('.js-dropdown-list-item');
         item._options.forEach((option, optionIndex) => {
-          if (option._isCorrect) {
-            const mcqInner = $options.eq(optionIndex + 1).find('.js-dropdown-list-item-inner');
-            mcqInner.find('.hint').remove();
-            mcqInner.append(`<span class="hint"> (${ariaLabels.correct})</span>`);
-          }
+          if (!option._isCorrect) return;
+          const mcqInner = $options.eq(optionIndex + 1).find('.js-dropdown-list-item-inner');
+          mcqInner.find('.hint').remove();
+          mcqInner.append(`<span class="hint"> (${ariaLabels.correct})</span>`);
         });
       });
       return;

--- a/less/devtools.less
+++ b/less/devtools.less
@@ -189,15 +189,18 @@
 }
 
 .mcq,
-.gmcq,
-.matching {
-  &__widget:not(.is-complete) &__item.hint-is-correct {
+.gmcq {
+  &__widget:not(.is-complete) &-item.hint-is-correct {
     opacity: 1;
   }
 
-  &__widget:not(.is-complete) &__item.hint-is-incorrect {
+  &__widget:not(.is-complete) &-item.hint-is-incorrect {
     opacity: 0.3;
   }
+}
+
+.matching-item .hint {
+  font-weight: @font-weight-bold;
 }
 
 .slider {


### PR DESCRIPTION
Fixes #113

### Fix
* Fix hinting in MCQ and GMCQ so that it dims incorrect answers
* Fix Matching to prevent "(correct)" from being shown repeatedly on each mouse click.
* Fix auto-answer logic to only remove hinting if a question is being answered rather than just a mouse click. Was causing `setMatchingHinting()` to use reverse logic for `hintingEnabled`.

### Update
* Change Matching to use `_globals._accessibility._ariaLabels.correct` instead of being hardcoded.
* Make "(correct)" bold for Matching hint. Remove unused style.

### Notes
* I did not test questionStrip or ppq which are currently supported

### Screenshots
Correct MCQ hinting behavior:

<img width="350" alt="mcq-dimmed" src="https://github.com/user-attachments/assets/168e28fb-67ac-48ad-8549-58235cb763b8" />

Incorrect repeated "(correct)" Matching behavior:

<img width="650" alt="Screenshot 2025-06-12 at 1 08 29 PM" src="https://github.com/user-attachments/assets/6a47a49a-ae70-412f-b2fb-1356772193b3" />
