### PR TITLE
Chore: include Mac option+click in auto correct tip (fixes #134)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Allows the user to toggle visual indicators which reveal how to answer correctly
 
 ### Auto correct
 
-When enabled, automatically provides the correct answer when submit is selected. If not enabled, the user can Control+Click or Alt+Click for Windows / Option+Click for macOS the submit button to have the correct answer provided. Standard question components will be answered naturally; revealing the correct responses, feedback and marking if applicable. The plugin will not attempt to do this for bespoke questions or questions that do not have correct answers (e.g. confidence slider), but their models will still be modified to indicate that they are complete and correct.
+When enabled, automatically provides the correct answer when submit is selected. If not enabled, the user can Control+Click or Alt+Click (Windows) / Option+Click (Mac) the submit button to have the correct answer provided. Adding Shift (Control+Shift+Click or Alt+Shift+Click on Windows / Option+Shift+Click on Mac) answers incorrectly instead. Standard question components will be answered naturally; revealing the correct responses, feedback and marking if applicable. The plugin will not attempt to do this for bespoke questions or questions that do not have correct answers (e.g. confidence slider), but their models will still be modified to indicate that they are complete and correct.
 
 ### Tutor
 

--- a/templates/devtools.hbs
+++ b/templates/devtools.hbs
@@ -44,7 +44,7 @@
 
   <div class="devtools__item is-tip auto-correct">
     <div class="devtools__item-inner">
-      <kbd>ctrl+click</kbd> submit to correctly answer questions (<kbd>ctrl+shift+click</kbd> for incorrect answer)
+      <kbd>ctrl+click</kbd> (Windows) or <kbd>option+click</kbd> (Mac) submit to correctly answer questions (add <kbd>shift</kbd> for incorrect answer)
     </div>
   </div>
 


### PR DESCRIPTION
Fixes #134

### Fix
- Drawer tip now shows the Mac `option+click` equivalent alongside `ctrl+click`, and states that adding `shift` answers incorrectly.
- README auto correct section now documents the incorrect-answer (Shift) variant for both Windows and Mac.

### Testing
1. Enable devtools, open the drawer, and confirm the auto correct tip reads: "ctrl+click (Windows) or option+click (Mac) submit to correctly answer questions (add shift for incorrect answer)".
2. On a Mac, option+click a question's submit button and confirm it answers correctly; option+shift+click and confirm it answers incorrectly.

Posted via collaboration with Claude Code