### PR TITLE
Update: auto fail exhausts attempts to finalise incorrect questions (fixes #136)

### DIFF
--- a/js/auto-answer.js
+++ b/js/auto-answer.js
@@ -90,6 +90,9 @@ class AutoAnswer extends Backbone.Controller {
         default:this.answerUnsupported(view);
       }
     }
+    // force final incorrect state in one action: the submit decrements _attemptsLeft to 0, so the
+    // question is marked complete/incorrect immediately rather than consuming one attempt at a time
+    if (incorrectly === true) view.model.set('_attemptsLeft', 1);
     view.$('.js-btn-action').trigger('click');
   }
 


### PR DESCRIPTION
Fixes #136

### Update
Answering a question incorrectly (ctrl/option+shift+click, or the **Fail**/**Half** buttons) now marks it as finally incorrect in a single action, regardless of the configured `_attempts`.

Previously each action consumed only one attempt: on a multi-attempt question the wrong selection was submitted, then cleared on "Try Again", so the question was only finally failed after the attempts had been used up over repeated clicks.

The incorrect-answer path now sets `_attemptsLeft` to 1 immediately before submitting, so core's submit handler decrements it to 0 and the question is marked complete/incorrect straight away (`_isComplete = _isCorrect || _attemptsLeft === 0`). Correct answers are unaffected — they already complete immediately.

### Testing
1. Add an MCQ with `_attempts: 3` and retry enabled.
2. Enable devtools and open a page with the question.
3. ctrl+shift+click (or option+shift+click on Mac) the submit button once.
4. Confirm the question is marked incorrect, complete, with marking shown and no attempts remaining — in a single action.
5. Repeat via the **Fail** button and confirm the same single-action finalisation. Confirm **Pass** still answers correctly in one click.

Posted via collaboration with Claude Code